### PR TITLE
Update autofill.js: parse autofill data from hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ce qui est proposé ici n'est en aucune facon prevu pour tricher/contourner quoi
 
 exemple d'URL :
 ```
-http://<containeraddress>/index.html?firstname=Jean&lastname=Dupont&birthday=01/01/1970&placeofbirth=Lyon&address=999 Avenue de France&city=Paris&zipcode=75000
+http://<containeraddress>/index.html#firstname=Jean&lastname=Dupont&birthday=01/01/1970&placeofbirth=Lyon&address=999 Avenue de France&city=Paris&zipcode=75000
 ```
 ## Crédits
 

--- a/autofill.js
+++ b/autofill.js
@@ -2,7 +2,7 @@
 function setFormValues()
 {
 	var form = document.forms["form-profile"];
-	var args = location.search.substr(1).split(/&/);
+	var args = location.hash.substr(1).split(/&/);
 	if (form.elements.length > 0) {
 		for (var i=0; i<args.length; ++i) {
 			var tmp = args[i].split(/=/);


### PR DESCRIPTION
In order to not send the form data and protect the personal data (in the case of use by several people / friends), the autofill data is in fragment identifier (the hash in URL) instead of GET parameters.

The browser will not send autofill data to the server if these parameters are in a fragment identifier.