### PR TITLE
Data privacy: parse autofill data from fragment identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ce qui est proposé ici n'est en aucune facon prevu pour tricher/contourner quoi
 
 exemple d'URL :
 ```
-http://<containeraddress>/index.html?firstname=Jean&lastname=Dupont&birthday=01/01/1970&placeofbirth=Lyon&address=999 Avenue de France&city=Paris&zipcode=75000
+http://<containeraddress>/index.html#firstname=Jean&lastname=Dupont&birthday=01/01/1970&placeofbirth=Lyon&address=999 Avenue de France&city=Paris&zipcode=75000
 ```
 ## Crédits
 

--- a/autofill.js
+++ b/autofill.js
@@ -3,7 +3,8 @@ import { $, $$, downloadBlob } from './dom-utils'
 function extractQueryString() {
   var params = {};
   var url = new URL(window.location);
-  for(var kv of url.searchParams.entries()) {
+  for(var hashParam of url.hash.substr(1).split(/&/)) {
+    var kv = decodeURIComponent(hashParam).split(/=/);
     if (kv[0] == "reason") {
       if (!("reasons" in params)) {
         params["reasons"] = [];


### PR DESCRIPTION
In order to not send the form data and protect the personal data (in the case of use by several people / friends), the autofill data parsed from fragment identifier (the hash in URL) instead of GET parameters.

The browser will not send autofill data to the server if these parameters are in a fragment identifier.